### PR TITLE
Shell input cutoff at character 512 and inf loop after 513+ characters are inputted

### DIFF
--- a/Stages/stage_1.c
+++ b/Stages/stage_1.c
@@ -13,7 +13,11 @@ char** ParseInput() {
 	// if the string doesn't contain \n or NULL
     if (strchr(buffer, '\n') == NULL) {
 		char chr = fgetc(stdin);
-        while (chr != '\n' && chr != EOF);
+        while (chr != '\n' && chr != EOF)
+		{
+			chr = '\0';
+			chr = fgetc(stdin);
+		};
 	}
 
 	// replace last character with \0, (find how many characters there are before the \n)

--- a/Stages/stage_1.h
+++ b/Stages/stage_1.h
@@ -4,7 +4,7 @@
 #include <string.h>
 
 // constants
-#define MAX_BUFFER_LENGTH 512
+#define MAX_BUFFER_LENGTH 513
 #define MAX_ARGS_QUANTITY 20
 #define TOKENS " \t|><&;"
 


### PR DESCRIPTION
fixes MAX_BUFFER_LENGTH
Added 1 to MAX_BUFFER_LENGTH so that the buffer doesn't cut out the 512th character.

Also fixes the issue of the code infinitely looping if the input to the shell is > 512 characters long
